### PR TITLE
Fix default rendering of images that are too wide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+1.0.1
+=====
+
+* (improvement) Fix default rendering of images that are too wide.
+
+
 1.0.0
 =====
 

--- a/reset/index.scss
+++ b/reset/index.scss
@@ -119,6 +119,7 @@ audio:not([controls]) {
 img {
 	border-style: none;
 	max-width: 100%;
+	height: auto;
 }
 
 iframe {


### PR DESCRIPTION
This will break on images that have defined dimensions but are being squeezed as they are too wide.